### PR TITLE
Put ProcessingHelpers in REVE namespace to let gem load properly in Rails

### DIFF
--- a/lib/reve/processing_helpers.rb
+++ b/lib/reve/processing_helpers.rb
@@ -1,4 +1,5 @@
-module ProcessingHelpers
+module REVE
+  module ProcessingHelpers
 
 # Helper method to handle nested assets
     def recur_through_assets(rows)
@@ -196,4 +197,5 @@ module ProcessingHelpers
 	  end
 	end
   
+  end
 end


### PR DESCRIPTION
Tried pulling REVE into a Rails app with bundler and it wouldn't load because ProcessingHelpers couldn't be found.  It needed to be put into the REVE module namespace like the other files, is all.